### PR TITLE
Fix workshop talk-id

### DIFF
--- a/index.html
+++ b/index.html
@@ -4723,7 +4723,7 @@
                                 </thead>
 
                                 <tbody>
-                                    <tr class="talk" id="talk-2-308">
+                                    <tr class="talk" id="talk-2-311">
                                         <td>
                                             Building a package that lasts
                                             <!--
@@ -4953,7 +4953,7 @@
                                 </thead>
 
                                 <tbody>
-                                    <tr class="talk" id="talk-2-311">
+                                    <tr class="talk" id="talk-2-309">
                                         <td>
                                             Automatic and Interpretable Machine Learning in R with H2O and LIME
                                             <!--
@@ -5063,7 +5063,7 @@
                                         </td>
                                     </tr>
 
-                                    <tr class="talk" id="talk-2-309">
+                                    <tr class="talk" id="talk-2-308">
                                         <td>
                                             Deep Learning with Keras for R
                                             <!--
@@ -5156,7 +5156,7 @@
                                         </td>
                                     </tr>
 
-                                    <tr class="talk" id="talk-2-312">
+                                    <tr class="talk" id="talk-2-313">
                                         <td>
                                             Plotting spatial data in R
                                             <!--
@@ -5196,7 +5196,7 @@
                                 </thead>
 
                                 <tbody>
-                                    <tr class="talk" id="talk-2-313">
+                                    <tr class="talk" id="talk-2-312">
                                         <td>
                                             Building a pipeline for reproducible data screening and quality control
                                             <!--


### PR DESCRIPTION
There are some workshops (e.g.: Deep Learning for Keras) in the schedule that point to other workshop abstracts.

This PR fixes the id-s of the talks.